### PR TITLE
Adding ERC6551 Demo + Has XMTP functionality

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -8,20 +8,14 @@ export const client = new ApolloClient({
 });
 
 export const getSocials = gql`
-  query GetSocials($address: [Identity!]) {
-    Socials(
-      input: { filter: { identity: { _in: $address } }, blockchain: ethereum }
-    ) {
-      Social {
+  query MyQuery($address: Identity!) {
+    Wallet(input: { identity: $address, blockchain: ethereum }) {
+      addresses
+      socials {
+        dappName
         profileName
-        dappName
       }
-    }
-    Domains(
-      input: { filter: { owner: { _in: $address } }, blockchain: ethereum }
-    ) {
-      Domain {
-        dappName
+      domains {
         name
       }
     }

--- a/api.ts
+++ b/api.ts
@@ -18,6 +18,9 @@ export const getSocials = gql`
       domains {
         name
       }
+      xmtp {
+        isXMTPEnabled
+      }
     }
   }
 `;

--- a/api.ts
+++ b/api.ts
@@ -167,7 +167,7 @@ export const getNFTHolders = gql`
     polygon: TokenNfts(
       input: {
         filter: { address: { _in: $address } }
-        blockchain: ethereum
+        blockchain: polygon
         limit: 200
       }
     ) {

--- a/api.ts
+++ b/api.ts
@@ -257,6 +257,53 @@ export const getPoapHolders = gql`
   }
 `;
 
+export const erc6551UserBalance = gql`
+  query MyQuery($owner: Identity!) {
+    TokenBalances(
+      input: {
+        filter: {
+          owner: { _eq: $owner }
+          tokenType: { _in: [ERC1155, ERC721] }
+        }
+        blockchain: ethereum
+        limit: 200
+      }
+    ) {
+      TokenBalance {
+        tokenNfts {
+          erc6551Accounts {
+            address {
+              addresses
+              tokenBalances {
+                tokenNfts {
+                  address
+                  contentValue {
+                    image {
+                      original
+                    }
+                  }
+                  type
+                  tokenId
+                }
+              }
+              socials {
+                dappName
+                profileName
+                identity
+              }
+            }
+          }
+          contentValue {
+            image {
+              original
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const challenge = gql`
   query Challenge($address: EthereumAddress!) {
     challenge(request: { address: $address }) {

--- a/app/airstack/ERC6551APIs.tsx
+++ b/app/airstack/ERC6551APIs.tsx
@@ -48,7 +48,6 @@ export function ERC6551APIs() {
       setLoading(false);
     }
   }
-  console.log(nfts);
   return (
     <div className="mt-4">
       <p className="font-bold mt-4 mb-4">Get ERC6551 Accounts</p>

--- a/app/airstack/ERC6551APIs.tsx
+++ b/app/airstack/ERC6551APIs.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { useState } from "react";
-import { getSocials } from "../../api";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
 import { Loading } from "../components/Loading";
 import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { erc6551UserBalance } from "../../api";
 
 const URI = "https://api.airstack.xyz/gql";
 
@@ -14,10 +14,8 @@ const client = new ApolloClient({
 });
 
 export function ERC6551APIs() {
-  const [domains, setDomains] = useState<any>([]);
-  const [socials, setSocials] = useState<any>([]);
-  const [addresses, setAddresses] = useState<any>([]); // List of address attach to `address` state (input)
   const [address, setAddress] = useState("");
+  const [nfts, setNfts] = useState<any>([]);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
   async function fetchProfiles() {
@@ -25,12 +23,16 @@ export function ERC6551APIs() {
     try {
       setLoading(true);
       setMessage("");
-      setDomains([]);
-      setSocials([]);
+      setNfts([]);
       const response = await client.query({
-        query: getSocials,
+        query: erc6551UserBalance,
+        /**
+         * Address to test out:
+         * - 0xa75b7833c78eba62f1c5389f811ef3a7364d44de: has NFT that has Lens (sapienz_0.lens)
+         * - 0xcf94ba8779848141d685d44452c975c2ddc04945: has lot of ERC6551 accounts
+         */
         variables: {
-          address,
+          owner: address,
         },
         context: {
           headers: {
@@ -38,30 +40,18 @@ export function ERC6551APIs() {
           },
         },
       });
-      const { Wallet } = response.data;
-      if (Wallet.addresses) {
-        setAddresses(Wallet.addresses);
-      }
-      if (Wallet.domains) {
-        setDomains(Wallet.domains);
-      }
-      if (Wallet.socials) {
-        setSocials(Wallet.socials);
-      }
-      if (!Wallet.domains && !Wallet.socials) {
-        setMessage("No profiles for this address.");
-      }
+      const { TokenBalances } = response.data;
+      setNfts(TokenBalances?.TokenBalance);
       setLoading(false);
     } catch (err) {
       console.log("error fetching profiles ...", err);
       setLoading(false);
     }
   }
+  console.log(nfts);
   return (
     <div className="mt-4">
-      <p className="font-bold mt-4 mb-4">
-        Get ERC6551 Accounts By Lens Profile
-      </p>
+      <p className="font-bold mt-4 mb-4">Get ERC6551 Accounts</p>
       <div className="flex flex-col items-start">
         <Input
           placeholder="Ethereum address, Lens Profile, or ENS"
@@ -76,33 +66,74 @@ export function ERC6551APIs() {
           className="bg-green-500 mt-2 mb-4"
         />
       </div>
-      {Boolean(addresses.length) && (
-        <>
-          <p className="text-red-500 text-lg">Addreses</p>
-          {addresses.map((addr) => (
-            <p key={addr}>{addr}</p>
-          ))}
-        </>
-      )}
-      {Boolean(domains.length) && (
-        <>
-          <p className="mt-4 text-green-500 text-lg">Domains</p>
-          {domains.map((domain) => (
-            <p key={domain.name}>{domain.name}</p>
-          ))}
-        </>
-      )}
-      {Boolean(socials.length) && (
-        <>
-          <p className="mt-4 text-blue-500 text-lg">Socials</p>
-          {socials.map((social) => (
-            <div key={social.profileName}>
-              <p>Protocol: {social.dappName}</p>
-              <p>Handle: {social.profileName}</p>
+      {nfts?.map(({ tokenNfts }, index) => {
+        const { contentValue, erc6551Accounts } = tokenNfts ?? {};
+        const { addresses, socials, tokenBalances } =
+          erc6551Accounts?.[0]?.address ?? [];
+        return (
+          <div key={index} className="flex flex-row p-2">
+            <div
+              style={{
+                backgroundImage: `url(${
+                  contentValue?.image?.original ?? "/fallback.png"
+                })`,
+                width: "150px",
+                aspectRatio: "1/1",
+                backgroundSize: "cover",
+              }}
+              className="basis-1/4"
+            />
+            <div className="basis-3/4 p-2">
+              {addresses && Boolean(addresses?.length) && (
+                <>
+                  <p className="text-red-500 text-lg">TBA Addreses</p>
+                  {addresses.map((addr) => (
+                    <a
+                      href={`https://etherscan.io/address/${addr}`}
+                      target="_blank"
+                      key={addr}
+                    >
+                      {addr}
+                    </a>
+                  ))}
+                </>
+              )}
+              {socials && Boolean(socials?.length) && (
+                <>
+                  <p className="mt-4 text-blue-500 text-lg">Socials</p>
+                  {socials.map((social) => (
+                    <div key={social.profileName}>
+                      <p>Protocol: {social.dappName}</p>
+                      <p>Handle: {social.profileName}</p>
+                    </div>
+                  ))}
+                </>
+              )}
+              {tokenBalances && Boolean(tokenBalances?.length) && (
+                <>
+                  <p className="mt-4 text-green-500 text-lg">Collectibles</p>
+                  <div className="flex flex-row gap-3">
+                    {tokenBalances.map(({ tokenNfts }, index) => (
+                      <div
+                        key={index}
+                        style={{
+                          backgroundImage: `url(${
+                            tokenNfts?.contentValue?.image?.original ??
+                            "/fallback.png"
+                          })`,
+                          width: "50px",
+                          aspectRatio: "1/1",
+                          backgroundSize: "cover",
+                        }}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
-          ))}
-        </>
-      )}
+          </div>
+        );
+      })}
       {loading && <Loading className="mt-4" />}
       {message && <p>{message}</p>}
     </div>

--- a/app/airstack/ERC6551APIs.tsx
+++ b/app/airstack/ERC6551APIs.tsx
@@ -13,7 +13,7 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-export function ProfileAPIs() {
+export function ERC6551APIs() {
   const [domains, setDomains] = useState<any>([]);
   const [socials, setSocials] = useState<any>([]);
   const [addresses, setAddresses] = useState<any>([]); // List of address attach to `address` state (input)
@@ -59,7 +59,9 @@ export function ProfileAPIs() {
   }
   return (
     <div className="mt-4">
-      <p className="font-bold mt-4 mb-4">Resolving Social Profiles</p>
+      <p className="font-bold mt-4 mb-4">
+        Get ERC6551 Accounts By Lens Profile
+      </p>
       <div className="flex flex-col items-start">
         <Input
           placeholder="Ethereum address, Lens Profile, or ENS"

--- a/app/airstack/EnhancementAPIs.tsx
+++ b/app/airstack/EnhancementAPIs.tsx
@@ -24,9 +24,9 @@ const EnhancementAPIs = () => {
   const [groupUsers, setGroupUsers] = useState<any[]>([]); // List of users in the focused group
 
   const fetchProfileGroups = async () => {
-    if (!lensHandle) return
+    if (!lensHandle) return;
     if (!lensHandle.includes(".lens")) {
-      lensHandle = lensHandle + ".lens"
+      lensHandle = lensHandle + ".lens";
     }
     setProfileGroups([]);
     try {
@@ -200,7 +200,7 @@ const EnhancementAPIs = () => {
       </div>
       <div className="mt-3 p-2 grid lg:grid-cols-4 md:grid-cols-2 grid-cols-1 gap-2">
         {recommendMode === "nfts" &&
-          profileGroups.map(({ tokenAddress, tokenNfts }, index) => (
+          profileGroups?.map(({ tokenAddress, tokenNfts }, index) => (
             <div key={index}>
               <img
                 src={tokenNfts?.contentValue?.image?.small ?? "/fallback.png"}
@@ -219,7 +219,7 @@ const EnhancementAPIs = () => {
             </div>
           ))}
         {recommendMode === "poaps" &&
-          profileGroups.map(({ eventId, image, name }, index) => (
+          profileGroups?.map(({ eventId, image, name }, index) => (
             <div key={index}>
               <img
                 src={image ?? "/fallback.png"}

--- a/app/airstack/ProfileAPIs.tsx
+++ b/app/airstack/ProfileAPIs.tsx
@@ -16,6 +16,7 @@ const client = new ApolloClient({
 export function ProfileAPIs() {
   const [domains, setDomains] = useState<any>([]);
   const [socials, setSocials] = useState<any>([]);
+  const [isXMTPEnabled, setIsXMTPEnabled] = useState<boolean>(false);
   const [addresses, setAddresses] = useState<any>([]); // List of address attach to `address` state (input)
   const [address, setAddress] = useState("");
   const [loading, setLoading] = useState(false);
@@ -48,7 +49,14 @@ export function ProfileAPIs() {
       if (Wallet.socials) {
         setSocials(Wallet.socials);
       }
-      if (!Wallet.domains && !Wallet.socials) {
+      if (Wallet?.xmtp?.[0]?.isXMTPEnabled) {
+        setIsXMTPEnabled(Wallet?.xmtp?.[0]?.isXMTPEnabled);
+      }
+      if (
+        !Wallet.domains &&
+        !Wallet.socials &&
+        !Wallet?.xmtp?.[0]?.isXMTPEnabled
+      ) {
         setMessage("No profiles for this address.");
       }
       setLoading(false);
@@ -99,6 +107,12 @@ export function ProfileAPIs() {
               <p>Handle: {social.profileName}</p>
             </div>
           ))}
+        </>
+      )}
+      {isXMTPEnabled && (
+        <>
+          <p className="mt-4 text-purple-500 text-lg">XMTP</p>
+          <p>{isXMTPEnabled ? "Enabled" : "Disabled"}</p>
         </>
       )}
       {loading && <Loading className="mt-4" />}

--- a/app/airstack/page.tsx
+++ b/app/airstack/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
             <p
               className={`
         mr-2 rounded-lg px-5 py-2 bg-slate-200
-         ${view === "profiles" ? "text-black" : "text-gray-400"}
+         ${view === "erc6551" ? "text-black" : "text-gray-400"}
         `}
             >
               ERC6551

--- a/app/airstack/page.tsx
+++ b/app/airstack/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 import { useState } from "react";
+import { ERC6551APIs } from "./ERC6551APIs";
 import { ProfileAPIs } from "./ProfileAPIs";
 import { RecommendationAPIs } from "./RecommendationAPIs";
 import EnhancementAPIs from "./EnhancementAPIs";
 
 export default function Home() {
-  const [view, setView] = useState("profiles");
+  const [view, setView] = useState("erc6551");
 
   return (
     <>
@@ -13,6 +14,16 @@ export default function Home() {
         <div>
           <p className="text-3xl text-slate-400 mb-4">Airstack</p>
           <p className="mb-2 font-bold">API type</p>
+          <button onClick={() => setView("erc6551")}>
+            <p
+              className={`
+        mr-2 rounded-lg px-5 py-2 bg-slate-200
+         ${view === "profiles" ? "text-black" : "text-gray-400"}
+        `}
+            >
+              ERC6551
+            </p>
+          </button>
           <button onClick={() => setView("profiles")}>
             <p
               className={`
@@ -44,6 +55,7 @@ export default function Home() {
             </p>
           </button>
         </div>
+        {view === "erc6551" && <ERC6551APIs />}
         {view === "profiles" && <ProfileAPIs />}
         {view === "recommendations" && <RecommendationAPIs />}
         {view === "enhancements" && <EnhancementAPIs />}


### PR DESCRIPTION
# New Features
- New section for getting all NFTs by 0x address or Lens and their ERC6551 account + NFT holdings in the ERC6551 account
- Check if XMTP is enabled in resolving social profile section

# Test input
- Try either `windle.eth` or `0xcf94ba8779848141d685d44452c975c2ddc04945` for testing ERC6551 account

# What's Left
- Fixing UI bug crash on Enhancement section, missing optional chaining
- Modify `GetNFTHolders` query to also query Polygon instead of Ethereum only